### PR TITLE
Restore to exact source of Blockbuilder parseCode.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "Geoffery Miller",
     "Paweł Kowalski",
     "Erik Hazzard",
-    "Curran Kelleher"
+    "Curran Kelleher",
+    "Micah Stubbs"
   ],
   "license": "BSD-3-Clause",
   "bugs": {


### PR DESCRIPTION
Incorporates changes by @micahstubbs from https://github.com/enjalot/blockbuilder/pull/194

Adds doctype to HTML, closes #4.

Want to ensure Blockbuilder feature parity in preparation for implementing **Blockbuilder: Adopt magic-sandbox #191** https://github.com/enjalot/blockbuilder/issues/191